### PR TITLE
Added charset to popup.html

### DIFF
--- a/dist/popup.html
+++ b/dist/popup.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <meta charset="utf-8">
     <title>Chrome Extension (built with TypeScript + React)</title>
     <script src="js/popup.js"></script>
 </head>


### PR DESCRIPTION
When I used Japanese, the popup.html's writing was garbled.

I think that adding charset is better since famous web pages have `<meta charset="utf-8">` such as google.com, github.com. 

